### PR TITLE
Download page update - add JFrog and read more link to Artifactory CE

### DIFF
--- a/css/downloads.css
+++ b/css/downloads.css
@@ -84,6 +84,9 @@
 .download-artifactory-additional .download-docker-img img {
     max-width: 65px;
 }
+#downloads .ce-more-link {
+    font-size: 12px;
+}
 #downloads .download-option {
     font-size: 12px;
 }

--- a/downloads.html
+++ b/downloads.html
@@ -148,11 +148,11 @@
             </div>
             <div class="col-lg-3 download-artifactory-ce">
                 <div class="row">
-                    <div class="col text-center pb-2 version">Artifactory 6.7</div>
+                    <div class="col text-center pb-2 version">JFrog Artifactory 6.7</div>
                 </div>
                 <div class="row">
                     <div class="col bgc-green-ce text-center text-white download-sub-header">
-                        <h2>Artifactory CE for C/C++</h2>
+                        <h2>JFrog Artifactory CE for C/C++</h2>
                     </div>
                 </div>
                 <div class="row justify-content-center">
@@ -163,6 +163,7 @@
                             <a href="https://jfrog.com/open-source/#conan"
                                target="_blank" class="jfrog-artifactory-ce-cta">
                                 <img src="img/C++.svg" class="img-c-plusplus" alt="Artifactory for C/C++ CE" />
+                                <p class="ce-more-link text-dark mt-2 mb-0">Learn more</p>
                             </a>
                             <div class="zip-install">
                                 <a href="https://api.bintray.com/content/jfrog/artifactory/jfrog-artifactory-cpp-ce-$latest.zip;bt_package=jfrog-artifactory-cpp-ce-zip"


### PR DESCRIPTION
Adding 'JFrog' to the Artifactory CE Download and 'learn more' text under the Logo for better visibility for the link.