### PR TITLE
Add canonical tag to conan pages

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="shortcut icon" type="image/png" href="favicon.png"/>
     <title>C/C++ Open Source Package Manager</title>
+    <link rel="canonical" href="https://conan.io/downloads" />
 
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="shortcut icon" type="image/png" href="favicon.png"/>
     <title>C/C++ Open Source Package Manager</title>
+    <link rel="canonical" href="https://conan.io/" />
 
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="shortcut icon" type="image/png" href="favicon.png"/>
     <title>Conan.io - Privacy Policy</title>
+    <link rel="canonical" href="https://conan.io/privacy-policy.html" />
 
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/css/bootstrap.min.css" integrity="sha384-Zug+QiDoJOrZ5t4lssLdxGhVrurbmBWopoEl+M6BdEfwnCJZtKxi1KgxUyJq13dy" crossorigin="anonymous">

--- a/terms-conditions.html
+++ b/terms-conditions.html
@@ -6,6 +6,7 @@
     <link rel="shortcut icon" type="image/png" href="favicon.png"/>
     <title>Conan.io - Terms and Conditions</title>
 
+    <link rel="canonical" href="https://conan.io/terms-conditions.html" />
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/css/bootstrap.min.css" integrity="sha384-Zug+QiDoJOrZ5t4lssLdxGhVrurbmBWopoEl+M6BdEfwnCJZtKxi1KgxUyJq13dy" crossorigin="anonymous">
     <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
(cherry picked from commit f3c8e8c)
This commit adds the canonical tags in the head of the pages in conan.io in order to improve SEO.