### PR TITLE
Download Windows 64 by default

### DIFF
--- a/src/downloads.html
+++ b/src/downloads.html
@@ -114,7 +114,7 @@
                           </a></div>
                       </div>
                     </div> <a class="cn-box cn-action cn-download" data-os="windows"
-                      href="https://dl.bintray.com/conan/installers/conan-win-32_1_34_0.exe"></a>
+                      href="https://dl.bintray.com/conan/installers/conan-win-64_1_34_0.exe"></a>
                   </div>
                   <div class="package-wrapper d-flex flex-no-wrap">
                     <div class="cn-box small"><img alt="Arc Linux" class="lazy"


### PR DESCRIPTION
fixes #240 

/cc @memsharded 

By default, 32 bits is listed for Windows. This PR changes it to use 64 instead.