### PR TITLE
add docker compose and default nginx conf for local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.5"
+
+services:
+    conan-io-local:
+        container_name: conan-io-local
+        build:
+            dockerfile: Dockerfile
+            context: .
+        networks:
+            - primary
+        volumes:
+           - type: bind
+             source: .
+             target: /app
+           - type: bind
+             source: ./nginx-local-conf
+             target: /etc/nginx/conf.d
+        networks:
+            primary:
+                aliases: 
+                    - conan-io-local
+        ports:
+            - "80:80"
+networks:
+    primary:

--- a/nginx-local-conf/default.conf
+++ b/nginx-local-conf/default.conf
@@ -1,0 +1,18 @@
+set_real_ip_from  127.0.0.1;
+real_ip_header    X-Forwarded-For;
+real_ip_recursive on;
+server {
+    listen 80 default_server;
+    server_tokens off;
+    server_name conan-io-local;
+    client_max_body_size 8192M;
+    location / {
+        add_header              Cache-Control "private";
+    }
+    location = /downloads {
+        return 301 /downloads.html;
+    }
+    location = /center {
+        return 301 /center/;
+    }
+}


### PR DESCRIPTION
The following command will now provision a new docker container and run the website in it.  It's available on localhost:80 by default.
```
docker-compose up -d
```
This is to be used for local development and preview within docker environment. 