### PR TITLE
Fix GitHub logo size in header

### DIFF
--- a/src/templates/header.html
+++ b/src/templates/header.html
@@ -35,7 +35,7 @@
                     <!-- Github -->
                     <a class="btn p-0 mr-3" href="https://github.com/conan-io/conan"
                        rel="nofollow noopener noreferrer" target="_blank">
-                        <img src="/img/small-github.svg" alt="Github">
+                        <img src="/img/small-github.svg" height="85%" alt="Github">
                     </a>
                     <div class="downloads-cta arrow-cta">
                         <div class="button_cont">


### PR DESCRIPTION
closes #292 Github button blurry on homepage

### Before

![image](https://user-images.githubusercontent.com/16867443/223579571-287e9e73-05cc-4391-9ecc-643aa36b13b1.png)

### After

![image](https://user-images.githubusercontent.com/16867443/223579607-d6431cc2-61d7-44cd-892f-69e9365cffc8.png)
